### PR TITLE
Fix work group count assertion

### DIFF
--- a/src/compute-pass-encoder.ts
+++ b/src/compute-pass-encoder.ts
@@ -68,9 +68,9 @@ wrapFunctionBefore(GPUComputePassEncoder, 'dispatchWorkgroups', function (this: 
   validateEncoderBindGroups(info.bindGroups, info.pipeline);
 
   const device = s_objToDevice.get(this)!;
-  assert(workgroupCountX < device.limits.maxComputeWorkgroupsPerDimension, () => `workGroupCountX(${workgroupCountX} > device.limits.maxComputeWorkgroupsPerDimension(${device.limits.maxComputeWorkgroupsPerDimension})`);
-  assert(workgroupCountY < device.limits.maxComputeWorkgroupsPerDimension, () => `workGroupCountY(${workgroupCountY} > device.limits.maxComputeWorkgroupsPerDimension(${device.limits.maxComputeWorkgroupsPerDimension})`);
-  assert(workgroupCountZ < device.limits.maxComputeWorkgroupsPerDimension, () => `workGroupCountZ(${workgroupCountZ} > device.limits.maxComputeWorkgroupsPerDimension(${device.limits.maxComputeWorkgroupsPerDimension})`);
+  assert(workgroupCountX <= device.limits.maxComputeWorkgroupsPerDimension, () => `workGroupCountX(${workgroupCountX}) > device.limits.maxComputeWorkgroupsPerDimension(${device.limits.maxComputeWorkgroupsPerDimension})`);
+  assert(workgroupCountY <= device.limits.maxComputeWorkgroupsPerDimension, () => `workGroupCountY(${workgroupCountY}) > device.limits.maxComputeWorkgroupsPerDimension(${device.limits.maxComputeWorkgroupsPerDimension})`);
+  assert(workgroupCountZ <= device.limits.maxComputeWorkgroupsPerDimension, () => `workGroupCountZ(${workgroupCountZ}) > device.limits.maxComputeWorkgroupsPerDimension(${device.limits.maxComputeWorkgroupsPerDimension})`);
 });
 
 const kIndirectDispatchWorkgroupsParametersSize = 12;


### PR DESCRIPTION
The current assertion fails when you are using the maximum allowed work group count. So as is, the Chrome extension will actually crash a perfectly valid WebGPU app.

This PR fixes the comparator to allow using the maximum amount of work groups.

Also there was a missing parentheses in the debug output.